### PR TITLE
Rest api 10.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="visonicalarm2",
-    version="3.1.2",
+    version="3.1.3",
     author="Andrea Liosi",
     author_email="andrea.liosi@gmail.com",
     description="A simple API library for the Visonic/Bentel/Tyco Alarm system.",

--- a/visonic/alarm.py
+++ b/visonic/alarm.py
@@ -223,8 +223,11 @@ class System(object):
         elif '9.0' in rest_versions:
             print('Rest API version 9.0 is supported.')
             self.__api.setVersionUrls('9.0')
+        elif '10.0' in rest_versions:
+            print('Rest API version 10.0 is supported.')
+            self.__api.setVersionUrls('10.0')
         else:
-            raise Exception('Rest API version 8.0 or 9.0 is not supported by server.')
+            raise Exception(f'Rest API version 8.0, 9.0 or 10.0 is not supported by server. Supported versions: {", ".join(rest_versions)}')
 
 
         # Try to login and get a user token.


### PR DESCRIPTION
Version 10 appears to be backwards compatible in the context of this package. I've tested getting devices, arming and disarming. 
Addresses https://github.com/And3rsL/VisonicAlarm2/issues/3